### PR TITLE
Fix encoding issue

### DIFF
--- a/util.rb
+++ b/util.rb
@@ -101,7 +101,6 @@ module Util
   # @param [String] message
   # @return [String]
   def self.format_message(message)
-    message = message.force_encoding('ASCII-8BIT')
     message.size.to_s + ':' + message
   end
 end


### PR DESCRIPTION
It looks like the new socket.io supports UTF-8 or something better so this line is unneeded and only causes crashes when special characters are sent through the bot.